### PR TITLE
Hide tiptap placeholder when tiptap has focus

### DIFF
--- a/components/_tiptap.scss
+++ b/components/_tiptap.scss
@@ -18,4 +18,12 @@ textarea.pat-tiptap {
          }
       }
    }
+   .ProseMirror-focused {
+      p[data-placeholder] {
+
+         &:before {
+             display: none;
+         }
+      }
+   }
 }


### PR DESCRIPTION
Currently the placeholder text is still visible when I focus an empty paragraph in the tiptap editor and only disappears when I start typing. I would expect it to get hidden on focus.

@cornae, this is probably the wrong way to fix it, but I hope you get the idea. :-)