### PR TITLE
Using a nonexistant glyph breaks a normal Jekyll build; use existing …

### DIFF
--- a/components/_upload.scss
+++ b/components/_upload.scss
@@ -38,7 +38,7 @@
 				cursor: default;
 
 				&:before {
-					content: "#{$glyph-upload-cloud}";
+					content: "#{$glyph-upload}";
 					font-family: fontello;
 					display: inline-block;
 					margin-right: 0.3em;


### PR DESCRIPTION
…upload glyph instead.